### PR TITLE
Fix CSS variable collisions

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,8 +21,8 @@
   {{ $grid    := resources.Get "css/game-grid.css" }}      
   {{ $global  := resources.Get "css/99-global.css" }}
   {{ $footer  := resources.Get "css/10-footer.css" }}
-  {{ $title := resources.Get "css/games-title-section.css" }}
-  {{ $title := resources.Get "css/discordbots-title-section.css" }}
+  {{ $gamesTitle := resources.Get "css/games-title-section.css" }}
+  {{ $discordTitle := resources.Get "css/discordbots-title-section.css" }}
   {{ $cta := resources.Get "css/cta-get-started.css" }}
   {{ $features := resources.Get "css/features-grid.css" }}
   {{ $discord := resources.Get "css/discord-bot-hosting.css" }}
@@ -42,8 +42,8 @@
        $faq
        $grid        
        $footer
-       $title
-       $title
+       $gamesTitle
+       $discordTitle
        $cta
        $features
        $discord


### PR DESCRIPTION
## Summary
- avoid variable name collisions when loading title CSS assets
- include both title section CSS files in the bundled slice

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850bdb63efc832b876f6f3cb6cd9aa4